### PR TITLE
add mobile cytoscape layout

### DIFF
--- a/.env
+++ b/.env
@@ -7,3 +7,4 @@ DISABLE_ESLINT_PLUGIN=true
 # https://github.com/facebook/create-react-app/pull/11752)
 # source maps are quite handy for debugging tools.
 GENERATE_SOURCEMAP=false
+HTTPS=true

--- a/src/components/pod-graph/cytoscape/index.ts
+++ b/src/components/pod-graph/cytoscape/index.ts
@@ -1,6 +1,5 @@
 import cytoscape, { CytoscapeOptions } from 'cytoscape';
-import dagre from 'cytoscape-dagre';
-import layout from './layout';
+import dagre, { DagreLayoutOptions } from 'cytoscape-dagre';
 import styles from './styles';
 import applyPanzoom from './panzoom';
 import applyEvents from './events';
@@ -15,7 +14,7 @@ type Deps = {
 };
 
 export default function createCytoscape(container: CytoscapeOptions['container'],
-  elements: CytoscapeOptions['elements'], deps: Deps) {
+  layout: DagreLayoutOptions, elements: CytoscapeOptions['elements'], deps: Deps) {
   const cy = cytoscape({
     container,
     layout,

--- a/src/components/pod-graph/cytoscape/layout.ts
+++ b/src/components/pod-graph/cytoscape/layout.ts
@@ -1,6 +1,6 @@
 import { DagreLayoutOptions } from 'cytoscape-dagre';
 
-const layout : DagreLayoutOptions = {
+export const desktopLayout : DagreLayoutOptions = {
   // whether to fit the viewport to the graph
   fit: true,
   // the padding on fit
@@ -40,4 +40,42 @@ const layout : DagreLayoutOptions = {
   stop() {},
 };
 
-export default layout;
+export const mobileLayout : DagreLayoutOptions = {
+  // whether to fit the viewport to the graph
+  fit: true,
+  // the padding on fit
+  padding: 250,
+  name: 'dagre',
+  nodeSep: 5,
+  edgeSep: 50,
+  rankSep: 250,
+  // 'TB' for top to bottom flow, 'LR' for left to right,
+  rankDir: 'TB',
+  // Type of algorithm to assign a rank to each node in the input graph.
+  // Possible values: 'network-simplex', 'tight-tree' or 'longest-path'
+  ranker: 'tight-tree',
+  // number of ranks to keep between the source and target of the edge
+  minLen() { return 1; },
+  // higher weight edges are generally made shorter and straighter than lower weight edges
+  edgeWeight() { return 1; },
+  // Applies a multiplicative factor (>0)  to expand or compress
+  // the overall area that the nodes take up
+  spacingFactor: undefined,
+  // whether labels should be included in determining the space used by a node
+  nodeDimensionsIncludeLabels: true,
+  // whether to transition the node positions
+  animate: false,
+  // whether to animate specific nodes when animation is on;
+  // non-animated nodes immediately go to their final positions
+  animateFilter() { return true; },
+  // duration of animation in ms if enabled
+  animationDuration: 500,
+  // easing of animation if enabled
+  animationEasing: undefined,
+  // a function that applies a transform to the final node position
+  transform(node, pos) { return pos; },
+  // on layoutready
+  ready() {},
+  // on layoutstop
+  stop() {},
+};

--- a/src/components/pod-graph/index.tsx
+++ b/src/components/pod-graph/index.tsx
@@ -6,6 +6,8 @@ import PodcastDetails from '../podcast-details';
 import ToggleBtn from '../buttons/toggle-button'; // This button can be used for another fn
 import { Podcast } from '../../client/interfaces';
 import { ExtendedCore } from './cytoscape/interfaces';
+import { useMediaQuery, useTheme } from '@mui/material';
+import { mobileLayout, desktopLayout } from './cytoscape/layout';
 
 const PodGraphContainer = styled.div`
   position: relative;
@@ -42,21 +44,26 @@ const PodGraph : React.FC<Props> = ({ subscriptions }) => {
   const selectedPodcast = subscriptions
     .find(subscription => subscription.subscribeUrl === selectedPodcastId);
 
+  const theme = useTheme();
+  const isSm = useMediaQuery(theme.breakpoints.down('sm'));
+
   if (selectedPodcastId && !selectedPodcast) {
     console.warn('Could not find a podcast with the selected ID. You should not be seeing this :)');
   }
 
   useEffect(() => {
-    const cyto = createCytoscape(el.current, getElementsFromSubscriptions(subscriptions), {
-      setSelectedPodcastId: (id) => setSelectedPodcastId(id),
-    });
+    const layout = isSm ? mobileLayout : desktopLayout;
+    const cyto = createCytoscape(el.current, layout,
+      getElementsFromSubscriptions(subscriptions), {
+        setSelectedPodcastId: (id) => setSelectedPodcastId(id),
+      });
     setCy(cyto);
     window.cy = cyto;
 
     return () => {
       cyto.destroy();
     };
-  }, [subscriptions]);
+  }, [subscriptions, isSm]);
 
   return (
     <PodGraphContainer>

--- a/src/pages/home.module.scss
+++ b/src/pages/home.module.scss
@@ -1,3 +1,10 @@
+.container {
+  margin: auto;
+  @media only screen and (max-width: 600px) {
+    max-width: 90%;
+  }
+}
+
 .leftPane {
   display: inline;
   max-width: 30%;

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -51,7 +51,7 @@ function HomePage() {
     subscribe(query);
   }
   return (
-    <div>
+    <div className={style.container}>
       <HeaderComponent onSubmit={search} />
 
       {subscriptions && (

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -6,6 +6,15 @@ export const theme = createTheme({
       main: '#fff',
     },
   },
+  breakpoints: {
+    values: {
+      xs: 0,
+      sm: 600,
+      md: 900,
+      lg: 1200,
+      xl: 1536,
+    },
+  },
   components: {
     MuiTabs: {
       styleOverrides: {


### PR DESCRIPTION
I experimented with some of the most famous layouts available for Cytoscape such as [Breadth-First](https://js.cytoscape.org/#layouts/breadthfirst), [Cose](https://js.cytoscape.org/#layouts/cose), [FCose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose), and [Elk ](https://github.com/cytoscape/cytoscape.js-elk) but our current layout ([Dagre](https://github.com/cytoscape/cytoscape.js-dagre)) seemed to be the most appropriate one on mobile.

